### PR TITLE
Python2 import fixes

### DIFF
--- a/memsee.py
+++ b/memsee.py
@@ -5,7 +5,6 @@ from __future__ import print_function
 from builtins import str
 from builtins import range
 from builtins import object
-from past.utils import old_div
 import functools
 import gzip
 import igraph

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ ipython[all]
 python-igraph >=0.7, <0.8
 git+https://github.com/quantopian/qgrid
 ujson
+future


### PR DESCRIPTION
Quick change to make mython2 work again, since there is no builtin module exposed.
