### PR TITLE
Set remote_js when rendering qgrids for portability

### DIFF
--- a/memsee.py
+++ b/memsee.py
@@ -572,7 +572,7 @@ class MemSeeApp(SqlMagic):
 
         self.results.append(results)
 
-        return qgrid.show_grid(results)
+        return qgrid.show_grid(results, remote_js=True)
 
     @need_db
     @handle_errors


### PR DESCRIPTION
Increases portability of notebooks by not requiring users to host/maintain js files next to notebooks. Also working with public ipython notebook viewers.
